### PR TITLE
Add redshiftdata clustername resource mapping

### DIFF
--- a/map.json
+++ b/map.json
@@ -77564,13 +77564,23 @@
         "RedshiftData.DescribeTable": [
             {
                 "action": "redshift-data:DescribeTable",
-                "resource_mappings": {}
+                "resource_mappings": {
+                    "ClusterName": {
+                        "template": "${ClusterIdentifier}"
+                    }
+                }
+
             }
         ],
         "RedshiftData.ExecuteStatement": [
             {
                 "action": "redshift-data:ExecuteStatement",
-                "resource_mappings": {}
+                "resource_mappings": {
+                    "ClusterName": {
+                        "template": "${ClusterIdentifier}"
+                    }
+                }
+
             }
         ],
         "RedshiftData.GetStatementResult": [
@@ -77582,13 +77592,22 @@
         "RedshiftData.ListDatabases": [
             {
                 "action": "redshift-data:ListDatabases",
-                "resource_mappings": {}
+                "resource_mappings": {
+                    "ClusterName": {
+                        "template": "${ClusterIdentifier}"
+                    }
+                }
             }
         ],
         "RedshiftData.ListSchemas": [
             {
                 "action": "redshift-data:ListSchemas",
-                "resource_mappings": {}
+                "resource_mappings": {
+                    "ClusterName": {
+                        "template": "${ClusterIdentifier}"
+                    }
+                }
+
             }
         ],
         "RedshiftData.ListStatements": [
@@ -77600,7 +77619,11 @@
         "RedshiftData.ListTables": [
             {
                 "action": "redshift-data:ListTables",
-                "resource_mappings": {}
+                "resource_mappings": {
+                    "ClusterName": {
+                        "template": "${ClusterIdentifier}"
+                    }
+                }
             }
         ],
         "SSOAdmin.AttachManagedPolicyToPermissionSet": [


### PR DESCRIPTION
As seen in iam_definition.json, the 5 affected resources need the `cluster*` resource. However, it is defined with a ClusterName, and not with ClusterIdentifier (as in the SDK request).

This PR adds the appropriate resource mappings to map.json.
The request layout can be seen here: https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_DescribeTable.html

I hope directly modifying this file is fine, I did not find any automation affecting this.

If there is anything still needed for this to go through, please let me know.