### PR TITLE
feat: Generate action-to-managed-policy mapping

### DIFF
--- a/util/aws_add_managed_policies.py
+++ b/util/aws_add_managed_policies.py
@@ -36,7 +36,6 @@ with open("MAMIP/DEPRECATED.json", "r") as f:
     deprecated_policies = json.loads(f.read())
 
 policies = []
-actions = {}
 
 for policyname in os.listdir("MAMIP/policies/"):
     policy = {}
@@ -187,8 +186,7 @@ for policyname in os.listdir("MAMIP/policies/"):
     access_levels = list(set(access_levels))
     access_levels.sort(key=lambda x: access_level_order[x])
 
-    for e in effective_actions:
-        actions.setdefault( e['effective_action'], {}).setdefault('managed_policies', []).append(policyname)
+    effective_action_names = [a['effective_action'] for a in effective_actions]
 
     policies.append({
         'name': policyname,
@@ -198,6 +196,7 @@ for policyname in os.listdir("MAMIP/policies/"):
         'updatedate': updatedate,
         'version': policy['PolicyVersion']['VersionId'],
         'malformed': malformed,
+        'effective_action_names': effective_action_names,
         'unknown_actions': (len(unknown_actions) > 0),
         'access_levels': access_levels,
         'privesc': privesc,
@@ -232,9 +231,4 @@ for policyname in os.listdir("MAMIP/policies/"):
 with open("aws/managed_policies.json", "w") as f:
     f.write(json.dumps({
         "policies": policies
-    }, indent=2, sort_keys=True))
-
-with open("aws/actions.json", "w") as f:
-    f.write(json.dumps({
-        "actions": actions,
     }, indent=2, sort_keys=True))

--- a/util/aws_add_managed_policies.py
+++ b/util/aws_add_managed_policies.py
@@ -36,6 +36,7 @@ with open("MAMIP/DEPRECATED.json", "r") as f:
     deprecated_policies = json.loads(f.read())
 
 policies = []
+actions = {}
 
 for policyname in os.listdir("MAMIP/policies/"):
     policy = {}
@@ -186,6 +187,9 @@ for policyname in os.listdir("MAMIP/policies/"):
     access_levels = list(set(access_levels))
     access_levels.sort(key=lambda x: access_level_order[x])
 
+    for e in effective_actions:
+        actions.setdefault( e['effective_action'], {}).setdefault('managed_policies', []).append(policyname)
+
     policies.append({
         'name': policyname,
         'arn': arn,
@@ -228,4 +232,9 @@ for policyname in os.listdir("MAMIP/policies/"):
 with open("aws/managed_policies.json", "w") as f:
     f.write(json.dumps({
         "policies": policies
+    }, indent=2, sort_keys=True))
+
+with open("aws/actions.json", "w") as f:
+    f.write(json.dumps({
+        "actions": actions,
     }, indent=2, sort_keys=True))


### PR DESCRIPTION
Part of https://github.com/iann0036/aws.permissions.cloud/issues/6

This generates a mapping from action to managed policies.
I do not have a strong opinion on JSON design, so I am flexible on it.