### PR TITLE
Added default headers for aws scraping

### DIFF
--- a/util/aws_parliament_update_iam_data.py
+++ b/util/aws_parliament_update_iam_data.py
@@ -12,15 +12,13 @@ from bs4 import BeautifulSoup
 # Code for get_links_from_base_actions_resources_conditions_page and update_html_docs_directory borrowed from https://github.com/salesforce/policy_sentry/blob/1126f174f49050b95bddf7549aedaf11fa51a50b/policy_sentry/scraping/awsdocs.py#L31
 BASE_DOCUMENTATION_URL = "https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html"
 
+DEFAULT_REQUESTS_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
+}
 
 def get_links_from_base_actions_resources_conditions_page():
     """Gets the links from the actions, resources, and conditions keys page, and returns their filenames."""
-
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
-    }
-
-    html = requests.get(BASE_DOCUMENTATION_URL, headers=headers)
+    html = requests.get(BASE_DOCUMENTATION_URL, headers=DEFAULT_REQUESTS_HEADERS)
     soup = BeautifulSoup(html.content, "html.parser")
     html_filenames = []
     try:
@@ -47,7 +45,7 @@ def update_html_docs_directory(html_docs_destination):
     html_filenames = [sub.replace("./", "") for sub in initial_html_filenames_list]
 
     for page in html_filenames:
-        response = requests.get(link_url_prefix + page, allow_redirects=False)
+        response = requests.get(link_url_prefix + page, allow_redirects=False, headers=DEFAULT_REQUESTS_HEADERS)
         # Replace the CSS stuff. Basically this:
         """
         <link href='href="https://docs.aws.amazon.com/images/favicon.ico"' rel="icon" type="image/ico"/>


### PR DESCRIPTION
In the second request, AWS asked for puzzle verification, so I included the user agent.

Therefore, the website https://aws.permissions.cloud/ is currently empty.