### PR TITLE
Adds "name" aka "ID" field to azure/built-in-roles-raw.json

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -54,7 +54,7 @@ jobs:
           python3 util/azure_process_spec.py
           az provider operation list > azure/provider-operations.json
           python3 util/azure_clean_provider_ops.py
-          az role definition list --query '[?roleType == `BuiltInRole`].{assignableScopes: assignableScopes, description: description, permissions: permissions, roleName: roleName, roleType: roleType, type: type}' > azure/built-in-roles-raw.json
+          az role definition list --query '[?roleType == `BuiltInRole`].{assignableScopes: assignableScopes, description: description, name:name, permissions: permissions, roleName: roleName, roleType: roleType, type: type}' > azure/built-in-roles-raw.json
           python3 util/azure_process_roles.py > azure/built-in-roles.json
           python3 util/azure_generate_map.py
           python3 util/aws_patch_iam_definition.py


### PR DESCRIPTION
    The command that fetches fields for each Azure built-in role
    currently does not save the "name" field, which is also known
    as the role ID field in Azure's documentation on built-in roles:
    https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles

    This field is important for my project, as it serves as a UID
    for each built-in-role. Would it be okay to update the code such
    that these roles are saved in built-in-roles-raw.json? That
    would save me a big headache in my project.

    Thank you! If you have any questions about this pull request,
    please do not hesitate to contact me.