### PR TITLE
Sort the list prior to json export

### DIFF
--- a/util/gcp_get_risks.py
+++ b/util/gcp_get_risks.py
@@ -24,13 +24,13 @@ for service_parent in os.listdir("iam-privilege-catalog/services/gcp/"):
                     for risk in contents["privileges"][privilege_name]["risks"]:
                         if risk == "escalation:privilege":
                             risks["PrivEsc"].append("{}.{}.{}".format(service_parent, service_basename, privilege_name))
-                            risks["PrivEsc"] = list(set(risks["PrivEsc"])) # dedup
+                            risks["PrivEsc"] = sorted(list(set(risks["PrivEsc"]))) # dedup
                         if risk == "exfiltration:data":
                             risks["DataAccess"].append("{}.{}.{}".format(service_parent, service_basename, privilege_name))
-                            risks["DataAccess"] = list(set(risks["DataAccess"])) # dedup
+                            risks["DataAccess"] = sorted(list(set(risks["DataAccess"]))) # dedup
                         if risk == "takeover:account":
                             risks["CredentialExposure"].append("{}.{}.{}".format(service_parent, service_basename, privilege_name))
-                            risks["CredentialExposure"] = list(set(risks["CredentialExposure"])) # dedup
+                            risks["CredentialExposure"] = sorted(list(set(risks["CredentialExposure"]))) # dedup
 
 with open("gcp/tags.json", "w") as f:
     f.write(json.dumps({"iam": risks}, indent=2, sort_keys=True))


### PR DESCRIPTION
gcp/tags.json contains list that are unsorted. This change sorted the list data prior to the json export to make future diff more managable.