### PR TITLE
Sort discoveryMethodologies prior to json export

### DIFF
--- a/util/gcp_crawl.py
+++ b/util/gcp_crawl.py
@@ -171,7 +171,7 @@ for root_service in methods.keys():
                 if not perminst['name'] in permdict.keys():
                     permdict[perminst['name']] = perminst
                 else:
-                    permdict[perminst['name']]['discoveryMethodologies'] = list(set(perminst['discoveryMethodologies']) | set(permdict[perminst['name']]['discoveryMethodologies']))
+                    permdict[perminst['name']]['discoveryMethodologies'] = sorted(list(set(perminst['discoveryMethodologies']) | set(permdict[perminst['name']]['discoveryMethodologies'])))
                     if 'parameterType' in perminst.keys():
                         permdict[perminst['name']]['parameterType'] = perminst['parameterType']
                     if 'resourceIndicator' in perminst.keys():


### PR DESCRIPTION
I notice the recent SAR update include a gcp/map.json diff that is a mere list value order changes. 

https://github.com/iann0036/iam-dataset/commit/a60a35577475dfd0c2e8744afd23b24081657923#diff-29b142d4483584da813cdd1e46bbecaddbc622305c2ac509bfa33e6f91aec221

Sort it prior to export will minimize future order changes.