### PR TITLE
fix: adds basic roles to predefined_roles.json and defines their perms

### DIFF
--- a/.github/workflows/data.yml
+++ b/.github/workflows/data.yml
@@ -36,6 +36,10 @@ jobs:
           rm -rf google-api-go-client/.git
           cd ..
           gcloud iam roles list --show-deleted --format json > gcp/predefined_roles.json
+          basic_roles=$(for role in roles/reader roles/writer roles/admin; do
+              gcloud iam roles describe "$role" --format json | jq 'del(.includedPermissions)'
+          done | jq -s -c 'flatten')
+          jq --argjson basic_roles "$basic_roles" '. + $basic_roles' gcp/predefined_roles.json > gcp/predefined_roles.json.tmp && mv gcp/predefined_roles.json.tmp gcp/predefined_roles.json
           gcloud iam roles list --show-deleted --format json | jq -r '.[]|[.name,(.name | split("/")[-1])] | @tsv' |
           while IFS=$'\t' read -r name shortname; do
               echo "Writing $shortname.json"


### PR DESCRIPTION
The command:
gcloud iam roles list --show-deleted --format json > gcp/predefined_roles.json

Lists all pre-defined roles and the legacy basic roles, which are: 
roles/viewer
roles/editor
roles/owner

But it does not list the three new basic roles that are meant to replace the viewer, editor, and owner roles. As these are in common use and should be included in this project, this fix adds them to role listing and by consequence results in their being defined in the roles directory:
roles/reader
roles/writer
roles/admin

These basic roles are described here in GCP documentation: https://cloud.google.com/iam/docs/roles-overview#basic

I should caution that these are in ALPHA state, so it is possible that in future GCP may begin to list these of its own accord when the following command is executed, in which case this update would not be helpful anymore: 
gcloud iam roles list --show-deleted --format json